### PR TITLE
Added PyTorch Attention 3D UNet models Stroke Lesion Segmention

### DIFF
--- a/DataPipeline/src/backend/torch/stroke-lesion-seg/brain_dataset.py
+++ b/DataPipeline/src/backend/torch/stroke-lesion-seg/brain_dataset.py
@@ -17,10 +17,7 @@ class StrokeMRIDataset(torch.utils.data.Dataset):
     def __len__(self):
         return len(self.brain_voxel_paths_)
 
-    def __getitem__(self, idx):
-        if self.debug:
-            print("idx = {}".format(idx))
-
+    def get_stroke_lesion_mris(self, idx):
         # sitk to torch tensor dims (channels, depth, height, width)
         if self.debug:
             print("self.brain_voxel_paths_[idx] = {}".format(self.brain_voxel_paths_[idx]))
@@ -38,5 +35,99 @@ class StrokeMRIDataset(torch.utils.data.Dataset):
         if self.debug:
             print("stroke_mask_voxel_tensor shape = {}".format(stroke_mask_voxel_tensor.shape))
         
+        return brain_voxel_tensor, stroke_mask_voxel_tensor
+
+    def __getitem__(self, idx):
+        if self.debug:
+            print("idx = {}".format(idx))
+
+        brain_voxel_tensor, stroke_mask_voxel_tensor = self.get_stroke_lesion_mris(idx)
+
+        return brain_voxel_tensor, stroke_mask_voxel_tensor
+
+
+class StrokeFilterMRIDataset(torch.utils.data.Dataset):
+    def __init__(self, brain_voxel_list, stroke_mask_list, stroke_type="both", debug=False):
+        self.brain_voxel_paths_ = brain_voxel_list
+        self.stroke_mask_paths_ = stroke_mask_list
+        self.stroke_type = stroke_type
+        self.brain_voxel_paths_, self.stroke_mask_paths_ = self.get_filtered_stroke_lesion_mris()
+        self.stroke_type = stroke_type
+        self.debug = debug
+
+    def __len__(self):
+        return len(self.brain_voxel_paths_)
+
+    def get_filtered_stroke_lesion_mris(idx):
+        # TODO (JG): Instead of using __getitem__ index, we'll iterate over lists and check our clinical labels if they equal our stroke_type
+
+        # sitk to torch tensor dims (channels, depth, height, width)
+        if self.debug:
+            print("self.voxid_to_prep_vox_paths_[idx] = {}".format(self.voxid_to_prep_vox_paths_[idx]))
+        with open(self.voxid_to_prep_vox_paths_[idx], "rb") as file:
+            pickle_voxid_to_prep_vox = pickle.load(file)
+        
+        voxel_id_from_prepvox = pickle_voxid_to_prep_vox[0]
+        prep_voxel_filepath = pickle_voxid_to_prep_vox[1]
+        prep_voxel = sitk.ReadImage(prep_voxel_filepath)
+        prep_voxel_array = sitk.GetArrayFromImage(prep_voxel)
+        prep_voxel_tensor = torch.tensor(prep_voxel_array).float()
+
+
+        # Will have a voxid and filepath
+        stroke_mask_voxel = sitk.ReadImage(self.stroke_mask_paths_[idx])
+        stroke_mask_voxel_array = sitk.GetArrayFromImage(stroke_mask_voxel)
+        stroke_mask_voxel_tensor = torch.from_numpy(stroke_mask_voxel_array).float()
+
+
+        if self.debug:
+            print("self.voxid_to_cap_paths_[idx] = {}".format(self.voxid_to_cap_paths_[idx]))
+
+        with open(self.voxid_to_cap_paths_[idx], "rb") as file:
+            pickle_voxid_to_prepcaps = pickle.load(file)
+
+        # check the clinical label, use it to filter list that we passed into Dataset, then use filtered list
+        voxel_id_from_caps = list(pickle_voxid_to_prepcaps.keys())[0]
+        prep_clinical_captions_list = list(pickle_voxid_to_prepcaps.values())[0]
+
+        # if self.caption_type == "short_caption":
+        clinical_label = prep_clinical_captions_list[0]
+            # print(f"short caption: clinical_label = {clinical_label}")
+        prep_captions_str = clinical_label
+        # elif self.caption_type == "long_caption":
+        #     caption = prep_clinical_captions_list[1]
+        #     # print(f"long caption: caption = {caption}")
+        #     prep_captions_str = caption
+
+        return brain_voxel_tensor, stroke_mask_voxel_tensor
+
+    def get_stroke_lesion_mris(self, idx):
+        # sitk to torch tensor dims (channels, depth, height, width)
+        if self.debug:
+            print("self.brain_voxel_paths_[idx] = {}".format(self.brain_voxel_paths_[idx]))
+        brain_voxel = sitk.ReadImage(self.brain_voxel_paths_[idx])
+        brain_voxel_array = sitk.GetArrayFromImage(brain_voxel)
+        brain_voxel_tensor = torch.tensor(brain_voxel_array).float()
+        if self.debug:
+            print("brain_voxel_tensor shape = {}".format(brain_voxel_tensor.shape))
+            print("self.stroke_mask_paths_[idx] = {}".format(self.stroke_mask_paths_[idx]))
+
+        stroke_mask_voxel = sitk.ReadImage(self.stroke_mask_paths_[idx])
+        stroke_mask_voxel_array = sitk.GetArrayFromImage(stroke_mask_voxel)
+        stroke_mask_voxel_tensor = torch.from_numpy(stroke_mask_voxel_array).float()
+
+        if self.debug:
+            print("stroke_mask_voxel_tensor shape = {}".format(stroke_mask_voxel_tensor.shape))
+        
+        return brain_voxel_tensor, stroke_mask_voxel_tensor
+
+
+    def __getitem__(self, idx):
+        if self.debug:
+            print("idx = {}".format(idx))
+
+
+        brain_voxel_tensor, stroke_mask_voxel_tensor = self.get_stroke_lesion_mris(idx)
+
         return brain_voxel_tensor, stroke_mask_voxel_tensor
 

--- a/DataPipeline/src/backend/torch/stroke-lesion-seg/torch_model.py
+++ b/DataPipeline/src/backend/torch/stroke-lesion-seg/torch_model.py
@@ -10,6 +10,40 @@ import monai
 # Reference perplexity.ai for pytorch 3D UNet skull strip seg model
 # https://www.perplexity.ai/search/0df235a1-27ba-4b67-bf7b-89c2500685c7?s=u
 
+# Add SeLU instead of ReLU
+class SESeLUBlock(nn.Module):
+    def __init__(self, in_channels, reduction_ratio=16):
+        super(SESeLUBlock, self).__init__()
+        self.avg_pool = nn.AdaptiveAvgPool3d(1)
+        self.fc1 = nn.Conv3d(in_channels, in_channels // reduction_ratio, kernel_size = 1, bias = False)
+        self.selu = nn.SELU(inplace=True)
+        self.fc2 = nn.Conv3d(in_channels // reduction_ratio, in_channels, kernel_size = 1, bias = False)
+        self.sigmoid = nn.Sigmoid()
+
+    def forward(self, x):
+        out = self.avg_pool(x)
+        out = self.fc1(out)
+        out = self.selu(out)
+        out = self.fc2(out)
+        out = self.sigmoid(out)
+        return x * out
+
+class SESeLUDoubleConv(nn.Module):
+    def __init__(self, in_channels, out_channels):
+        super(SESeLUDoubleConv, self).__init__()
+        self.conv = nn.Sequential(
+            nn.Conv3d(in_channels, out_channels, kernel_size=3, padding=1, bias=False),
+            nn.BatchNorm3d(out_channels),
+            nn.SELU(inplace=True),
+            nn.Conv3d(out_channels, out_channels, kernel_size=3, padding=1, bias=False),
+            nn.BatchNorm3d(out_channels),
+            nn.SELU(inplace=True),
+            SESeLUBlock(in_channels=out_channels)
+        )
+
+    def forward(self, x):
+        return self.conv(x)
+
 # Add attention gates using the Squeeze-and-Excitation (SE) block
 class SEBlock(nn.Module):
     def __init__(self, in_channels, reduction_ratio=16):
@@ -209,6 +243,82 @@ class AttSEUNet3D(nn.Module):
             # Concatenate skip connections and add them along channel dimensions (ex: we have batch, channel, h, w)
             concat_skip = torch.cat((skip_connection, x), dim=1)
             # Then run through SEDoubleConv
+            x = self.upsampling3d[idx+1](concat_skip)
+
+        return self.final_conv3d(x)
+
+
+class AttSESeLUUNet3D(nn.Module):
+    def __init__(self, in_channels=3, out_channels=1, hidden_features=[64, 128, 256, 512], debug=False):
+        super(AttSESeLUUNet3D, self).__init__()
+        self.debug = debug
+
+        self.upsampling3d = nn.ModuleList()
+        self.downsampling3d = nn.ModuleList()
+
+        # self.avg_max_pool3d = nn.AdaptiveMaxPool3d(2)
+        self.pool3d = nn.MaxPool3d(kernel_size=2, stride=2)
+
+        # Downsampling encoder part of UNET
+        for feature in hidden_features:
+            self.downsampling3d.append(SESeLUDoubleConv(in_channels, feature))
+            in_channels = feature
+
+        # Upsampling decoder part of UNET
+        for feature in reversed(hidden_features):
+            # we do ConvTranspose2d for up, then SESeLUDoubleConv for 2 convs
+            self.upsampling3d.append(
+                nn.ConvTranspose3d(
+                    feature*2, feature, kernel_size=2, stride=2
+                )
+            )
+            self.upsampling3d.append(SESeLUDoubleConv(feature*2, feature))
+
+        self.bottleneck3d = SESeLUDoubleConv(hidden_features[-1], hidden_features[-1]*2)
+
+        self.final_conv3d = nn.Conv3d(hidden_features[0], out_channels, kernel_size=1)
+
+
+    def forward(self, x):
+        skip_connections3d = []
+
+        # we loop for downsampling
+        for down3d in self.downsampling3d:
+            x = down3d(x)
+            # for skip connections, ordering is important here, first is highest resolution, last is smallest resolution
+            skip_connections3d.append(x)
+            x = self.avg_max_pool3d(x)
+
+        x = self.bottleneck3d(x)
+
+        # now go backwards to make skip connections easier, reverse list, go with skip connections with highest res to lowest res
+        skip_connections3d = skip_connections3d[::-1]
+
+        # we loop taking steps of 2 for upsampling with SESeLUDoubleConv
+        for idx in range(0, len(self.upsampling3d), 2):
+            # upsample with ConvTranspose2d
+            x = self.upsampling3d[idx](x)
+            # Divide idx by 2 to get just idx since we're doing step by 2 above
+            skip_connection = skip_connections3d[idx//2]
+
+            # Soln to cases when not divisible by 2 issue
+                # NOTE: in the UNET paper, they did cropping, but we'll do resizing for this issue
+            if x.shape != skip_connection.shape:
+                # we check x from outward part of upsampling, ifnequal resize our x using skip_connection resolutions just by channels, ignore h & w
+                if self.debug:
+                    print("x.shape = {}".format(x.shape))
+                    print("skip_connection.shape = {}".format(skip_connection.shape))
+                    print("skip_connection.shape[2:] = {}".format(skip_connection.shape[2:]))
+                # x = TF.resize(x, size=skip_connection.shape[2:])
+                x = F.interpolate(x, size=skip_connection.shape[2:], mode="trilinear", align_corners=False)
+                # monai_resize3d = monai.transforms.Resize(spatial_size=skip_connection.shape[2:])
+                # x = monai_resize3d(x)
+
+            if self.debug:
+                print("Concatenating skip connections")
+            # Concatenate skip connections and add them along channel dimensions (ex: we have batch, channel, h, w)
+            concat_skip = torch.cat((skip_connection, x), dim=1)
+            # Then run through SESeLUDoubleConv
             x = self.upsampling3d[idx+1](concat_skip)
 
         return self.final_conv3d(x)


### PR DESCRIPTION
**WORKS**: I have included 2 Attention 3D UNet models: both have Squeeze Excitation for the basis of attention unet, the first version AttSEUNet3D uses SE block with relus and the second version AttSESeLUUNet3D uses SE blocks with SeLU activation functions. Both UNet models put their version of SE blocks into Double Convolution blocks.

**IN_PROGRESS**: Also started adding support for dealing with Stroke Types where we have preprocessed stroke MRIs that only include Ischemic Stroke, or only include Hemorrhagic Stroke or both. I plan to do a follow up PR to handle the case where we want to first train 3D UNet on Ischemic Stroke, then later filter for Hemorrhagic stroke and apply transfer learning on our pre-trained 3D UNet, so it also learns 3D lesion segmentation for this other case. Currently, we just take a preprocessed dataset of Stroke MRIs of both cases and train our 3D UNet model on them. Curious if we can get better results taking filtered training appraoch.